### PR TITLE
Symfony <2.7.8 constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     },
     "require": {
         "php": ">=5.3.9",
-        "symfony/symfony": "2.7.*",
+        "symfony/symfony": "2.7.* <2.7.8",
         "doctrine/orm": "^2.4.8",
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "~2.3",


### PR DESCRIPTION
I found that symfony 2.7.8 and greater breaks installation because of a weird problem during cache building process, ending up in a wrong declaration of appDevDebugProjectContainer::getFosUser_UserManagerService method in app/cache/dev/appDevDebugProjectContainer.php.
In fact, for some strange reason, using symfony 2.7.8 the method is built receiving the jms_serializer service instead of doctrine as the fourth parameter of its constructor.

